### PR TITLE
Fix loaded check position

### DIFF
--- a/plugin/qbuf.vim
+++ b/plugin/qbuf.vim
@@ -2,16 +2,16 @@ if v:version < 700
 	finish
 endif
 
+if exists("g:qb_loaded") && g:qb_loaded
+	finish
+endif
+let g:qb_loaded = 1
+
 if !exists("g:qb_hotkey") || g:qb_hotkey == ""
 	let g:qb_hotkey = "<F4>"
 endif
 exe "nnoremap <unique>" g:qb_hotkey " :cal <SID>init(1)<cr>:cal SBRun()<cr>"
 exe "cnoremap <unique>" g:qb_hotkey "<Esc>"
-
-if exists("g:qb_loaded") && g:qb_loaded
-	finish
-endif
-let g:qb_loaded = 1
 
 let s:action2cmd = {"z": 'call <SID>switchbuf(#,"")', "!z": 'call <SID>switchbuf(#,"!")',
 			\"u": "hid b #|let s:cursel = (s:cursel+1) % s:blen",


### PR DESCRIPTION
I'd like to change "g:qb_loaded" potision.
Because to avoid duplicate `nnoremap <unique>` call.
